### PR TITLE
Set the number of columns used for 2D cross correlation alignment

### DIFF
--- a/pyreduce/reduce.py
+++ b/pyreduce/reduce.py
@@ -1173,6 +1173,8 @@ class WavelengthCalibrationFinalize(Step):
         self.dimensionality = config["dimensionality"]
         #:int: Number of detector offset steps, due to detector design
         self.nstep = config["nstep"]
+        #:int: How many columns to use in the 2D cross correlation alignment. 0 means all pixels (slow).
+        self.correlate_cols = config['correlate_cols']
         #:float: fraction of columns, to allow individual orders to shift
         self.shift_window = config["shift_window"]
         #:str: elements of the spectral lamp
@@ -1220,6 +1222,7 @@ class WavelengthCalibrationFinalize(Step):
             iterations=self.iterations,
             dimensionality=self.dimensionality,
             nstep=self.nstep,
+            correlate_cols=self.correlate_cols,
             shift_window=self.shift_window,
             element=self.element,
             medium=self.medium,

--- a/pyreduce/settings/settings_pyreduce.json
+++ b/pyreduce/settings/settings_pyreduce.json
@@ -98,6 +98,7 @@
             6
         ],
         "nstep": 0,
+        "correlate_cols": 0,
         "shift_window": 0.01,
         "element": "thar",
         "medium": "vac",

--- a/pyreduce/settings/settings_schema.json
+++ b/pyreduce/settings/settings_schema.json
@@ -369,6 +369,11 @@
                             "description": "Use only manual order alignment if true. When false still allow manual alignment after automatic alignment if plot is true",
                             "type": "boolean"
                         },
+                        "correlate_cols": {
+                            "description": "The number of columns used for 2D cross correlation alignment. 0 means all pixels (slow).",
+                            "type": "integer",
+                            "minimum": 0
+                        },
                         "shift_window": {
                             "description": "The fraction of the columns that each order can be shifted individually to align with the reference",
                             "type": "number",


### PR DESCRIPTION
Hi Ansgar,

As part of the wavelength calibration procedure, each ThAr spectrum gets cross correlated in 2D against a synthetic spectrum made from the line list. This is definitely a useful step, but for someone with a large detector and many wavelength calibrations per night, it becomes very time consuming. I therefore added the option of aligning only with X central columns (e.g. 500) instead of the full size of the array (4096 in our case). This speeds things up significantly, although still producing accurate results.

All the best
René